### PR TITLE
Android 12 support

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -33,6 +33,7 @@
         <config-file target="AndroidManifest.xml" parent="/manifest">
             <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
             <uses-permission android:name="android.permission.BLUETOOTH"/>
+            <uses-permission android:name="android.permission.BLUETOOTH_CONNECT"/>
             <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
         </config-file>
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -66,6 +66,6 @@
         </podspec>
 
         <dependency id="cordova-plugin-add-swift-support" version="2.0.2"/>
-        <dependency id="cordova-plugin-file" version="^7.0.0" />
+        <dependency id="cordova-plugin-file" version="^6.0.0" />
     </platform>
 </plugin>

--- a/src/android/DfuUpdate.java
+++ b/src/android/DfuUpdate.java
@@ -36,7 +36,8 @@ public class DfuUpdate extends CordovaPlugin {
 	private String fileURL;
 	private final String COARSE = Manifest.permission.ACCESS_COARSE_LOCATION;
 	private final String BLUETOOTH = Manifest.permission.BLUETOOTH;
-	private final String [] permissions = { COARSE, BLUETOOTH};
+	private final String BLUETOOTH_CONNECT = Manifest.permission.BLUETOOTH_CONNECT;
+	private final String [] permissions = { COARSE, BLUETOOTH, BLUETOOTH_CONNECT };
 
 	@Override
 	public boolean execute(String action, JSONArray args, CallbackContext callbackContext) throws JSONException {
@@ -93,7 +94,7 @@ public class DfuUpdate extends CordovaPlugin {
 	}
 
 	private boolean hasPerms() {
-		return cordova.hasPermission(COARSE) && cordova.hasPermission(BLUETOOTH);
+		return cordova.hasPermission(COARSE) && (cordova.hasPermission(BLUETOOTH) || cordova.hasPermission(BLUETOOTH_CONNECT));
 	}
 
 


### PR DESCRIPTION
New android permission BLUETOOTH_CONNECT is needed in android 12 (SDK >= 31) to connect to Bluetooth devices.